### PR TITLE
msm8226-common: Ship missing OMX codecs decoders.

### DIFF
--- a/proprietary-blobs.txt
+++ b/proprietary-blobs.txt
@@ -134,3 +134,8 @@ vendor/lib/libqc-opt.so
 vendor/lib/libDivxDrm.so
 vendor/lib/libmmosal.so
 vendor/lib/libSHIMDivxDrm.so
+vendor/lib/libOmxAacDec.so
+vendor/lib/libOmxAmrwbplusDec.so
+vendor/lib/libOmxEvrcDec.so
+vendor/lib/libOmxQcelp13Dec.so
+vendor/lib/libOmxWmaDec.so


### PR DESCRIPTION
The encoders are being built from source,so what about the decoders?