### PR TITLE
msm8226-common: Enforce RRO on framework-res.

### DIFF
--- a/msm8226.mk
+++ b/msm8226.mk
@@ -101,9 +101,6 @@ PRODUCT_PACKAGES += \
     libwcnss_qmi
 endif
 
-PRODUCT_ENFORCE_RRO_TARGETS := \
-    framework-res
-
 # Audio
 PRODUCT_PACKAGES += \
     android.hardware.audio@2.0-impl \


### PR DESCRIPTION
Overlays only for framework-res will be converted into RROs.

Other overlays can't be converted due to some known issues on app RRO. # #